### PR TITLE
Change default location of screenshots

### DIFF
--- a/setupbin/mac-setup.sh
+++ b/setupbin/mac-setup.sh
@@ -16,6 +16,11 @@ brew tap caskroom/cask
 
 brew cask install google-chrome
 
+# Change screenshot location to something more appropriate than desktop
+mkdir ~/Documents/Screenshots
+
+defaults write com.apple.screencapture location ~/Documents/Screenshots
+
 # Change editor
 export EDITOR=nano
 


### PR DESCRIPTION
Just a suggestion - rather than clog the desktop up with screenshots (using <kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>3</kbd> or <kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>4</kbd>, put them in their own directory in `~/Documents/Screenshots`